### PR TITLE
Do not fail if hosts is nil

### DIFF
--- a/lib/capistrano/locally.rb
+++ b/lib/capistrano/locally.rb
@@ -12,6 +12,7 @@ module Capistrano
     alias original_on on
 
     def on(hosts, options={}, &block)
+      return unless hosts
       localhosts, remotehosts = hosts.partition { |h| h.hostname.to_s == 'localhost' }
       localhost = Configuration.env.filter(localhosts).first
 


### PR DESCRIPTION
Hi,

sometimes it happens that `hosts` variable comes as `nil` so the deployment crashes. Here's a quick fix.
