### PR TITLE
Fix possible method missing exception for partition

### DIFF
--- a/lib/capistrano/locally.rb
+++ b/lib/capistrano/locally.rb
@@ -13,7 +13,13 @@ module Capistrano
 
     def on(hosts, options={}, &block)
       return unless hosts
-      localhosts, remotehosts = hosts.partition { |h| h.hostname.to_s == 'localhost' }
+      if hosts.respond_to? :partition
+        localhosts, remotehosts = hosts.partition { |h| h.hostname.to_s == 'localhost' }
+      elsif hosts.hostname.to_s == 'localhost'
+        localhosts = [hosts]
+      else
+        remotehosts = hosts
+      end
       localhost = Configuration.env.filter(localhosts).first
 
       unless localhost.nil?


### PR DESCRIPTION
In some cases capistrano pass only a single host to on function. In this case there is no partition method.  
The idea of this patch is just to work around this issue. I reproduce it with Capistrano Version: 3.4.0 (Rake Version: 10.5.0) on rails 4.2.1
