### PR TITLE
Fix error on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ So, you don't need to write SSH user and configs on `server 'localhost'`.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'capistrano-locally'
+gem 'capistrano-locally', require: false
 ```
 
 And then execute:


### PR DESCRIPTION
capistrano 3.10.0 and capistrano-locally raise error on booting rails.

Adding `require: false` to `gem 'capistrano-locally'` fixed this error, so I think we need it in README.

## Error log

```
NameError: uninitialized constant Capistrano::Configuration::SSHKit
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-3.10.0/lib/capistrano/configuration/server.rb:4:in `<class:Configuration>'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-3.10.0/lib/capistrano/configuration/server.rb:3:in `<module:Capistrano>'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-3.10.0/lib/capistrano/configuration/server.rb:2:in `<top (required)>'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-3.10.0/lib/capistrano/configuration.rb:4:in `require_relative'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-3.10.0/lib/capistrano/configuration.rb:4:in `<top (required)>'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-3.10.0/lib/capistrano/configuration/filter.rb:1:in `<top (required)>'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-3.10.0/lib/capistrano/dsl.rb:5:in `<top (required)>'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/capistrano-locally-0.2.4/lib/capistrano/locally.rb:2:in `<top (required)>'
/var/www/linkers/releases/20171211080024/config/application.rb:9:in `<top (required)>'
/var/www/linkers/releases/20171211080024/Rakefile:5:in `<top (required)>'
/var/www/linkers/shared/bundle/ruby/2.2.0/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
/home/app/.rbenv/versions/2.2.6/bin/bundle:23:in `load'
/home/app/.rbenv/versions/2.2.6/bin/bundle:23:in `<main>'
```