### PR TITLE
Use pristine Bundler environment when executing local commands

### DIFF
--- a/lib/capistrano/locally.rb
+++ b/lib/capistrano/locally.rb
@@ -17,11 +17,18 @@ module Capistrano
       localhost = Configuration.env.filter(localhosts).first
 
       unless localhost.nil?
-        if dry_run?
-          SSHKit::Backend::Printer
+        klass = if dry_run?
+                  SSHKit::Backend::Printer
+                else
+                  SSHKit::Backend::Local
+                end
+        if defined? Bundler
+          Bundler.with_clean_env do
+            klass.new(localhost, &block).run
+          end
         else
-          SSHKit::Backend::Local
-        end.new(localhost, &block).run
+          klass.new(localhost, &block).run
+        end
       end
 
       original_on(remotehosts, options, &block)


### PR DESCRIPTION
Bundler is leaking ENV variables when running local commands, which leads to unexpected behaviour.

In our case bundle commands were executed with the local Gemfile path instead of the release Gemfile.