### PR TITLE
Add a way to inherit environment variables and execute commands

### DIFF
--- a/lib/capistrano/locally.rb
+++ b/lib/capistrano/locally.rb
@@ -22,7 +22,7 @@ module Capistrano
                 else
                   SSHKit::Backend::Local
                 end
-        if defined? Bundler
+        if (defined? Bundler) && fetch(:run_locally_with_clean_env, true)
           Bundler.with_clean_env do
             klass.new(localhost, &block).run
           end


### PR DESCRIPTION
In various capistrano plugins, you may want to refer to environment variables without using bundler in the block.

In order to solve this problem, if run_locally_with_clean_env is false, execute the command by taking over the environment variable.