### PR TITLE
use `Bundler.with_unbundled_env` instead of `Bundler.with_clean_env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Require in `Capfile`:
     server 'localhost', roles: %w{app web} # no need to set SSH configs.
 
 ### Options
-**`:run_locally_with_clean_env`** (default: `true`)
+**`:run_locally_with_unbundled_env`** (default: `true`)
 
-When using bundler, commands are executed in `Bundler.with_clean_env` by default so as not to affect the executable ruby scripts. To explicitly inherit environment variables, set this `false`.
+Previous name is **`run_locally_with_clean_env`**.
+When using bundler, commands are executed in `Bundler.with_unbundled_env` by default so as not to affect the executable ruby scripts. To explicitly inherit environment variables, set this `false`.
 
 ## Development
 

--- a/lib/capistrano/locally.rb
+++ b/lib/capistrano/locally.rb
@@ -22,8 +22,9 @@ module Capistrano
                 else
                   SSHKit::Backend::Local
                 end
-        if (defined? Bundler) && fetch(:run_locally_with_clean_env, true)
-          Bundler.with_clean_env do
+
+        if (defined? Bundler) && fetch_setting_related_bundler_with_unbundled_env
+          Bundler.with_unbundled_env do
             klass.new(localhost, &block).run
           end
         else
@@ -38,6 +39,26 @@ module Capistrano
 
     def dry_run?
       fetch(:sshkit_backend) == SSHKit::Backend::Printer
+    end
+
+    def fetch_setting_related_bundler_with_unbundled_env
+      value = fetch(:run_locally_with_unbundled_env)
+      value = fetch_run_locally_with_clean_env if use.nil?
+      value = true if use.nil?
+
+      value
+    end
+
+    def fetch_run_locally_with_clean_env
+      value = fetch(:run_locally_with_clean_env)
+
+      unless value.nil?
+        $stderr.puts(<<-MESSAGE)
+[Deprecation Notice] `set :run_locally_with_clean_env` has been deprecated in favor of `set :run_locally_with_unbundled_env`.
+MESSAGE
+      end
+
+      value
     end
   end
 end


### PR DESCRIPTION
This fixes the following warning:

```
[DEPRECATED] Bundler.with_clean_env has been deprecated in favor of Bundler.with_unbundled_env. If you instead want the environment before bundler was originally loaded, use Bundler.with_original_env (called at /app/.bundle/vendor/ruby/3.0.0/gems/capistrano-locally-0.2.7/lib/capistrano/locally.rb:26)
```